### PR TITLE
JSON 직렬화 로직 유틸리티로 분리

### DIFF
--- a/data/src/commonMain/kotlin/com/peto/droidmorning/data/datasource/answer/remote/DefaultRemoteAnswerDataSource.kt
+++ b/data/src/commonMain/kotlin/com/peto/droidmorning/data/datasource/answer/remote/DefaultRemoteAnswerDataSource.kt
@@ -9,8 +9,8 @@ import com.peto.droidmorning.data.model.request.RpcDefaultRequest
 import com.peto.droidmorning.data.model.request.UpdateAnswerRequest
 import com.peto.droidmorning.data.model.response.AnswerHistoryResponse
 import com.peto.droidmorning.data.model.response.CurrentAnswerResponse
+import com.peto.droidmorning.data.util.JsonUtil
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 
@@ -18,7 +18,7 @@ class DefaultRemoteAnswerDataSource(
     private val postgrest: PostgrestClient,
     private val authClient: AuthClient,
 ) : RemoteAnswerDataSource {
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = JsonUtil.defaultJson
 
     override suspend fun fetchCurrentAnswer(questionId: Long): CurrentAnswerResponse? =
         postgrest
@@ -30,10 +30,10 @@ class DefaultRemoteAnswerDataSource(
                         PostgrestFilter(QUESTION_ID_COLUMN, questionId),
                     ),
             ).let { data ->
-                json
-                    .decodeFromString(
-                        ListSerializer(CurrentAnswerResponse.serializer()),
+                JsonUtil
+                    .decode(
                         data,
+                        ListSerializer(CurrentAnswerResponse.serializer()),
                     ).firstOrNull()
             }
 
@@ -48,9 +48,9 @@ class DefaultRemoteAnswerDataSource(
                     ),
                 order = PostgrestOrder(CREATED_AT_COLUMN, descending = true),
             ).let { data ->
-                json.decodeFromString(
-                    ListSerializer(AnswerHistoryResponse.serializer()),
+                JsonUtil.decode(
                     data,
+                    ListSerializer(AnswerHistoryResponse.serializer()),
                 )
             }
 

--- a/data/src/commonMain/kotlin/com/peto/droidmorning/data/datasource/exam/remote/DefaultRemoteExamDataSource.kt
+++ b/data/src/commonMain/kotlin/com/peto/droidmorning/data/datasource/exam/remote/DefaultRemoteExamDataSource.kt
@@ -7,11 +7,11 @@ import com.peto.droidmorning.core.network.PostgrestOrder
 import com.peto.droidmorning.data.model.request.toRequest
 import com.peto.droidmorning.data.model.response.ExamDetailResponse
 import com.peto.droidmorning.data.model.response.ExamHistoryResponse
+import com.peto.droidmorning.data.util.JsonUtil
 import com.peto.droidmorning.domain.model.category.Category
 import com.peto.droidmorning.domain.model.exam.Exams
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 
@@ -19,7 +19,7 @@ class DefaultRemoteExamDataSource(
     private val postgrest: PostgrestClient,
     private val authClient: AuthClient,
 ) : RemoteExamDataSource {
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = JsonUtil.defaultJson
 
     override suspend fun submitExam(
         exam: Exams,
@@ -33,7 +33,7 @@ class DefaultRemoteExamDataSource(
                         .encodeToJsonElement(exam.toRequest(uid(), categories))
                         .jsonObject,
             ).let { data ->
-                json.decodeFromString(Long.serializer(), data)
+                JsonUtil.decode(data, Long.serializer())
             }
 
     override suspend fun fetchExamHistory(): List<ExamHistoryResponse> =
@@ -43,9 +43,9 @@ class DefaultRemoteExamDataSource(
                 filters = listOf(PostgrestFilter(USER_ID_COLUMN, uid())),
                 order = PostgrestOrder(UPDATED_AT_COLUMN, descending = true),
             ).let { data ->
-                json.decodeFromString(
-                    ListSerializer(ExamHistoryResponse.serializer()),
+                JsonUtil.decode(
                     data,
+                    ListSerializer(ExamHistoryResponse.serializer()),
                 )
             }
 
@@ -58,9 +58,9 @@ class DefaultRemoteExamDataSource(
                         .encodeToJsonElement(mapOf(RPC_PARAM_EXAM_ID to examId))
                         .jsonObject,
             ).let { data ->
-                json.decodeFromString(
-                    ListSerializer(ExamDetailResponse.serializer()),
+                JsonUtil.decode(
                     data,
+                    ListSerializer(ExamDetailResponse.serializer()),
                 )
             }
 

--- a/data/src/commonMain/kotlin/com/peto/droidmorning/data/datasource/question/remote/DefaultRemoteQuestionDataSource.kt
+++ b/data/src/commonMain/kotlin/com/peto/droidmorning/data/datasource/question/remote/DefaultRemoteQuestionDataSource.kt
@@ -8,8 +8,8 @@ import com.peto.droidmorning.data.model.request.LikeRequest
 import com.peto.droidmorning.data.model.response.CategoryCountResponse
 import com.peto.droidmorning.data.model.response.ExamQuestionResponse
 import com.peto.droidmorning.data.model.response.QuestionResponse
+import com.peto.droidmorning.data.util.JsonUtil
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 
@@ -17,7 +17,7 @@ class DefaultRemoteQuestionDataSource(
     private val postgrest: PostgrestClient,
     private val authClient: AuthClient,
 ) : RemoteQuestionDataSource {
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = JsonUtil.defaultJson
 
     override suspend fun fetchExamQuestions(): List<QuestionResponse> =
         postgrest
@@ -28,9 +28,9 @@ class DefaultRemoteQuestionDataSource(
                         .encodeToJsonElement(mapOf(RPC_FETCH_QUESTIONS_PARAM_NAME to uid()))
                         .jsonObject,
             ).let { data ->
-                json.decodeFromString(
-                    ListSerializer(QuestionResponse.serializer()),
+                JsonUtil.decode(
                     data,
+                    ListSerializer(QuestionResponse.serializer()),
                 )
             }
 
@@ -46,9 +46,9 @@ class DefaultRemoteQuestionDataSource(
                         .encodeToJsonElement(ExamQuestionRequest(category, count))
                         .jsonObject,
             ).let { data ->
-                json.decodeFromString(
-                    ListSerializer(ExamQuestionResponse.serializer()),
+                JsonUtil.decode(
                     data,
+                    ListSerializer(ExamQuestionResponse.serializer()),
                 )
             }
 
@@ -77,9 +77,9 @@ class DefaultRemoteQuestionDataSource(
         postgrest
             .rpc(RPC_CATEGORY_COUNT)
             .let { data ->
-                json.decodeFromString(
-                    ListSerializer(CategoryCountResponse.serializer()),
+                JsonUtil.decode(
                     data,
+                    ListSerializer(CategoryCountResponse.serializer()),
                 )
             }
 

--- a/data/src/commonMain/kotlin/com/peto/droidmorning/data/util/JsonUtil.kt
+++ b/data/src/commonMain/kotlin/com/peto/droidmorning/data/util/JsonUtil.kt
@@ -1,0 +1,13 @@
+package com.peto.droidmorning.data.util
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+
+object JsonUtil {
+    val defaultJson: Json = Json { ignoreUnknownKeys = true }
+
+    fun <T> decode(
+        data: String,
+        serializer: KSerializer<T>,
+    ): T = defaultJson.decodeFromString(serializer, data)
+}


### PR DESCRIPTION
## 이슈 번호
#40

## 작업내용
JSON 직렬화 로직을 공통 유틸로 분리해 중복을 줄였습니다.

## 결과물
N/A

| Before | After |
|:--:|:--:|
| N/A | N/A |